### PR TITLE
feat(ct): add adapter for default proxy

### DIFF
--- a/.changeset/metal-rice-suffer.md
+++ b/.changeset/metal-rice-suffer.md
@@ -1,0 +1,5 @@
+---
+'@chugsplash/contracts': minor
+---
+
+Implements the adapter for the default proxy.

--- a/packages/contracts/contracts/IProxyAdapter.sol
+++ b/packages/contracts/contracts/IProxyAdapter.sol
@@ -1,8 +1,31 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
+/**
+ * @title IProxyAdapter
+ * @notice Interface that must be inherited by each adapter.
+ */
 interface IProxyAdapter {
+    /**
+     * @notice Returns the current implementation of the proxy.
+     *
+     * @param _proxy Address of the proxy.
+     */
     function getProxyImplementation(address payable _proxy) external returns (address);
 
+    /**
+     * @dev Upgrade the implementation of the proxy.
+     *
+     * @param _proxy          Address of the proxy.
+     * @param _implementation Address of the new implementation.
+     */
     function upgradeProxyTo(address payable _proxy, address _implementation) external;
+
+    /**
+     * @notice Changes the admin of the proxy.
+     *
+     * @param _proxy    Address of the proxy.
+     * @param _newAdmin Address of the new admin.
+     */
+    function changeProxyAdmin(address payable _proxy, address _newAdmin) external;
 }

--- a/packages/contracts/contracts/adapters/TransparentUpgradeableAdapter.sol
+++ b/packages/contracts/contracts/adapters/TransparentUpgradeableAdapter.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import { IProxyAdapter } from "../IProxyAdapter.sol";
+import {
+    TransparentUpgradeableProxy
+} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+/**
+ * @title TransparentUpgradeableAdapter
+ * @notice Adapter for an OpenZeppelin Transparent Upgradeable proxy. This is the adapter used by
+ *         default proxies in the ChugSplash system. To learn more about the transparent proxy
+ *         pattern, see: https://docs.openzeppelin.com/contracts/4.x/api/proxy#transparent_proxy
+ */
+contract TransparentUpgradeableAdapter is IProxyAdapter {
+    /**
+     * @inheritdoc IProxyAdapter
+     */
+    function getProxyImplementation(address payable _proxy) external returns (address) {
+        return TransparentUpgradeableProxy(_proxy).implementation();
+    }
+
+    /**
+     * @inheritdoc IProxyAdapter
+     */
+    function upgradeProxyTo(address payable _proxy, address _implementation) external {
+        TransparentUpgradeableProxy(_proxy).upgradeTo(_implementation);
+    }
+
+    /**
+     * @inheritdoc IProxyAdapter
+     */
+    function changeProxyAdmin(address payable _proxy, address _newAdmin) external {
+        TransparentUpgradeableProxy(_proxy).changeAdmin(_newAdmin);
+    }
+}


### PR DESCRIPTION
A simple adapter for the default proxy used by ChugSplash, which is OpenZeppelin's `TransparentUpgradeableProxy`.